### PR TITLE
Added Swedish

### DIFF
--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -8,6 +8,7 @@ pub mod russian;
 pub mod belarusian;
 pub mod german;
 pub mod polish;
+pub mod swedish;
 
 
 /// Helper function to make a language dynamically dispatched
@@ -37,6 +38,7 @@ pub fn from_isolang(x : isolang::Language) -> Option<Box<super::Language>> {
         x if x.to_name() == "German"     => boxup(german::German),
         x if x.to_name() == "Belarusian" => boxup(belarusian::Belarusian),
         x if x.to_name() == "Polish"     => boxup(polish::Polish),
+        x if x.to_name() == "Swedish"    => boxup(swedish::Swedish),
         _ => return None,
     })
 }

--- a/src/languages/swedish.rs
+++ b/src/languages/swedish.rs
@@ -1,0 +1,40 @@
+use super::super::{Language, TimeUnit};
+
+/// Default language for timeago
+#[derive(Default)]
+pub struct Swedish;
+impl Language for Swedish {
+    fn too_low (&self) -> &'static str { "nu" }
+    fn too_high(&self) -> &'static str { "gammal" }
+    fn ago(&self)      -> &'static str { "sedan" }
+    fn get_word(&self, tu: TimeUnit, x: u64) -> &'static str {
+        use TimeUnit::*;
+        if x == 1 {
+            match tu {
+                Nanoseconds   =>  "nanosekund",
+                Microseconds  =>  "mikrosekund",
+                Milliseconds  =>  "millisekund",
+                Seconds       =>  "sekund",
+                Minutes       =>  "minut",
+                Hours         =>  "timme",
+                Days          =>  "dag",
+                Weeks         =>  "vecka",
+                Months        =>  "månad",
+                Years         =>  "år",
+            }
+        } else {
+            match tu {
+                Nanoseconds   =>  "nanosekunder",
+                Microseconds  =>  "mikrosekunder",
+                Milliseconds  =>  "millisekunder",
+                Seconds       =>  "sekunder",
+                Minutes       =>  "minuter",
+                Hours         =>  "timmar",
+                Days          =>  "dagar",
+                Weeks         =>  "veckor",
+                Months        =>  "månader",
+                Years         =>  "år",
+            }
+        }
+    }
+}


### PR DESCRIPTION
As per the title.

One small problem is that something like `5 minutes 3 seconds` (in Swedish of course) sounds a bit weird to a natives speaker, it should have an “and” between the parts. I don’t want to mock around too much in the source, and the current way it is is fine.