### PR TITLE
Update travis rustc version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.20.0
+  - 1.33.0
 script:
   - cargo build --all-features --verbose --all
   - cargo test --all-features --verbose --all


### PR DESCRIPTION
Travis CI failed in PR #16 I believe because it's using an ancient rustc version.

This PR updates rustc version from 1.20 to current stable 1.33 