### PR TITLE
Add `Language::between_chunks` and `between_value_and_word`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,12 @@ pub trait Language {
     fn place_unit_before(&self, _: u64) -> bool {
         false
     }
+    fn between_chunks(&self) -> &str {
+        " "
+    }
+    fn between_value_and_word(&self) -> &str {
+        " "
+    }
 
     /// Make a dynamic copy of this language
     fn clone_boxed(&self) -> BoxedLanguage;
@@ -444,7 +450,11 @@ impl<L: Language> Formatter<L> {
             if now != "0" {
                 return now.to_owned();
             } else {
-                ret = format!("0 {}", self.lang.get_word(self.min_unit, 0));
+                ret = format!(
+                    "0{}{}",
+                    self.lang.between_value_and_word(),
+                    self.lang.get_word(self.min_unit, 0)
+                );
             }
         }
 
@@ -483,12 +493,14 @@ impl<L: Language> Formatter<L> {
         let recurse_result = self.convert_impl(rem, items_left - 1);
 
         let word = self.lang.get_word(dtu, x);
+        let between = self.lang.between_value_and_word();
+        let between_chunk = self.lang.between_chunks();
 
         match (self.lang.place_unit_before(x), recurse_result.is_empty()) {
-            (true, true) => format!("{word} {x}"),
-            (true, false) => format!("{word} {x} {recurse_result}"),
-            (false, true) => format!("{x} {word}"),
-            (false, false) => format!("{x} {word} {recurse_result}"),
+            (true, true) => format!("{word}{between}{x}"),
+            (true, false) => format!("{word}{between}{x}{between_chunk}{recurse_result}"),
+            (false, true) => format!("{x}{between}{word}"),
+            (false, false) => format!("{x}{between}{word}{between_chunk}{recurse_result}"),
         }
     }
 }


### PR DESCRIPTION
These methods make it possible to customize the whitespace in the output. This enables additional punctuation (like the commas proposed in https://github.com/vi/timeago/pull/11) and abbreviated output formats (often desired in command-line applications, like `1h 30m 15s`).

The default implementations encode the previous behavior; therefore, no change is made to the observed behavior of the library.

For an example using this feature, see https://github.com/vi/timeago/pull/37.