### PR TITLE
fix: correct `between_chunks` and `between_value_and_word` for `BoxedLanguage`

### DIFF
--- a/src/languages/korean.rs
+++ b/src/languages/korean.rs
@@ -41,40 +41,45 @@ impl Language for Korean {
 fn test() {
     use super::super::Formatter;
     use std::time::Duration;
-    let mut f = Formatter::with_language(Korean);
-    f.min_unit(TimeUnit::Seconds);
-    assert_eq!(f.convert(Duration::from_secs(0)), "방금");
-    assert_eq!(f.convert(Duration::from_nanos(42)), "방금");
-    assert_eq!(f.convert(Duration::from_micros(42)), "방금");
-    assert_eq!(f.convert(Duration::from_millis(42)), "방금");
-    assert_eq!(f.convert(Duration::from_secs(42)), "42초 전");
-    assert_eq!(f.convert(Duration::from_mins(42)), "42분 전");
-    assert_eq!(f.convert(Duration::from_hours(2)), "2시간 전");
-    assert_eq!(f.convert(Duration::from_hours(23)), "23시간 전");
-    assert_eq!(f.convert(Duration::from_hours(24)), "1일 전");
-    assert_eq!(f.convert(Duration::from_hours(24 + 1)), "1일 전");
-    assert_eq!(f.convert(Duration::from_hours(2 * 24 - 1)), "1일 전");
-    assert_eq!(f.convert(Duration::from_hours(2 * 24)), "2일 전");
-    assert_eq!(f.convert(Duration::from_hours(2 * 24 + 1)), "2일 전");
-    assert_eq!(f.convert(Duration::from_hours(3 * 24 - 1)), "2일 전");
-    assert_eq!(f.convert(Duration::from_hours(3 * 24)), "3일 전");
-    assert_eq!(f.convert(Duration::from_hours(3 * 24 + 1)), "3일 전");
-    assert_eq!(f.convert(Duration::from_hours(42 * 24)), "1개월 전");
-    assert_eq!(f.convert(Duration::from_hours(364 * 24)), "11개월 전");
-    assert_eq!(f.convert(Duration::from_hours(365 * 24)), "11개월 전");
-    assert_eq!(f.convert(Duration::from_hours(366 * 24)), "1년 전");
-    assert_eq!(f.convert(Duration::from_hours(42 * 366 * 24)), "42년 전");
+    
+    fn test_with_formatter<L: Language>(mut f: Formatter<L>) {
+        f.min_unit(TimeUnit::Seconds);
+        assert_eq!(f.convert(Duration::from_secs(0)), "방금");
+        assert_eq!(f.convert(Duration::from_nanos(42)), "방금");
+        assert_eq!(f.convert(Duration::from_micros(42)), "방금");
+        assert_eq!(f.convert(Duration::from_millis(42)), "방금");
+        assert_eq!(f.convert(Duration::from_secs(42)), "42초 전");
+        assert_eq!(f.convert(Duration::from_mins(42)), "42분 전");
+        assert_eq!(f.convert(Duration::from_hours(2)), "2시간 전");
+        assert_eq!(f.convert(Duration::from_hours(23)), "23시간 전");
+        assert_eq!(f.convert(Duration::from_hours(24)), "1일 전");
+        assert_eq!(f.convert(Duration::from_hours(24 + 1)), "1일 전");
+        assert_eq!(f.convert(Duration::from_hours(2 * 24 - 1)), "1일 전");
+        assert_eq!(f.convert(Duration::from_hours(2 * 24)), "2일 전");
+        assert_eq!(f.convert(Duration::from_hours(2 * 24 + 1)), "2일 전");
+        assert_eq!(f.convert(Duration::from_hours(3 * 24 - 1)), "2일 전");
+        assert_eq!(f.convert(Duration::from_hours(3 * 24)), "3일 전");
+        assert_eq!(f.convert(Duration::from_hours(3 * 24 + 1)), "3일 전");
+        assert_eq!(f.convert(Duration::from_hours(42 * 24)), "1개월 전");
+        assert_eq!(f.convert(Duration::from_hours(364 * 24)), "11개월 전");
+        assert_eq!(f.convert(Duration::from_hours(365 * 24)), "11개월 전");
+        assert_eq!(f.convert(Duration::from_hours(366 * 24)), "1년 전");
+        assert_eq!(f.convert(Duration::from_hours(42 * 366 * 24)), "42년 전");
 
-    f.min_unit(TimeUnit::Nanoseconds);
-    assert_eq!(f.convert(Duration::from_nanos(42)), "42나노초 전");
-    assert_eq!(f.convert(Duration::from_micros(42)), "42마이크로초 전");
-    assert_eq!(f.convert(Duration::from_millis(42)), "42밀리초 전");
+        f.min_unit(TimeUnit::Nanoseconds);
+        assert_eq!(f.convert(Duration::from_nanos(42)), "42나노초 전");
+        assert_eq!(f.convert(Duration::from_micros(42)), "42마이크로초 전");
+        assert_eq!(f.convert(Duration::from_millis(42)), "42밀리초 전");
 
-    f.max_unit(TimeUnit::Months);
-    assert_eq!(f.convert(Duration::from_hours(365 * 24)), "11개월 전");
-    assert_eq!(f.convert(Duration::from_hours(366 * 24)), "12개월 전");
+        f.max_unit(TimeUnit::Months);
+        assert_eq!(f.convert(Duration::from_hours(365 * 24)), "11개월 전");
+        assert_eq!(f.convert(Duration::from_hours(366 * 24)), "12개월 전");
 
-    f.max_duration(Duration::from_hours(365 * 24));
-    assert_eq!(f.convert(Duration::from_hours(365 * 24)), "11개월 전");
-    assert_eq!(f.convert(Duration::from_hours(366 * 24)), "오래전");
+        f.max_duration(Duration::from_hours(365 * 24));
+        assert_eq!(f.convert(Duration::from_hours(365 * 24)), "11개월 전");
+        assert_eq!(f.convert(Duration::from_hours(366 * 24)), "오래전");
+    }
+
+    test_with_formatter(Formatter::with_language(Korean));
+    test_with_formatter(Formatter::with_language(Korean.clone_boxed()));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,14 +76,23 @@ impl Language for BoxedLanguage {
     fn ago(&self) -> &'static str {
         (**self).ago()
     }
+    fn get_word(&self, tu: TimeUnit, x: u64) -> &'static str {
+        (**self).get_word(tu, x)
+    }
     fn place_ago_before(&self) -> bool {
         (**self).place_ago_before()
     }
     fn override_space_near_ago(&self) -> &str {
         (**self).override_space_near_ago()
     }
-    fn get_word(&self, tu: TimeUnit, x: u64) -> &'static str {
-        (**self).get_word(tu, x)
+    fn place_unit_before(&self, x: u64) -> bool {
+        (**self).place_unit_before(x)
+    }
+    fn between_chunks(&self) -> &str {
+        (**self).between_chunks()
+    }
+    fn between_value_and_word(&self) -> &str {
+        (**self).between_value_and_word()
     }
 }
 


### PR DESCRIPTION
Hello, this PR fixes a broken implementation of `BoxedLanguage` for the following methods:

- `between_chunks`
- `between_value_and_word`

Each method has a default implementation, which cannot be accessed through the `Box<dyn Language>` format.
Therefore, as in other cases, we should propagate the actual implementation as follows:

```rust
impl Language for BoxedLanguage {
    // actual patches
    fn between_chunks(&self) -> &str {
        (**self).between_chunks()
    }
    fn between_value_and_word(&self) -> &str {
        (**self).between_value_and_word()
    }
    ...
}
```
