### PR TITLE
fix: drop word spacing in Japanese ("5 分 前" -> "5分前")

### DIFF
--- a/src/languages/japanese.rs
+++ b/src/languages/japanese.rs
@@ -30,4 +30,43 @@ impl Language for Japanese {
             Years => "年",
         }
     }
+    // Japanese doesn't separate words with spaces, so drop the default " "
+    // between the value, the unit, and the trailing "前": "5 分 前" -> "5分前".
+    fn between_value_and_word(&self) -> &str {
+        ""
+    }
+    fn between_chunks(&self) -> &str {
+        ""
+    }
+    fn override_space_near_ago(&self) -> &str {
+        ""
+    }
+}
+
+#[test]
+fn test() {
+    use super::super::Formatter;
+    use std::time::Duration;
+
+    fn test_with_formatter<L: Language>(mut f: Formatter<L>) {
+        f.min_unit(TimeUnit::Seconds);
+        assert_eq!(f.convert(Duration::from_secs(0)), "今");
+        assert_eq!(f.convert(Duration::from_nanos(42)), "今");
+        assert_eq!(f.convert(Duration::from_micros(42)), "今");
+        assert_eq!(f.convert(Duration::from_millis(42)), "今");
+        assert_eq!(f.convert(Duration::from_secs(42)), "42秒前");
+        assert_eq!(f.convert(Duration::from_mins(42)), "42分前");
+        assert_eq!(f.convert(Duration::from_hours(2)), "2時間前");
+        assert_eq!(f.convert(Duration::from_hours(24)), "1日前");
+        assert_eq!(f.convert(Duration::from_hours(7 * 24)), "1週間前");
+
+        f.num_items(2);
+        assert_eq!(f.convert(Duration::from_secs(3600 + 42)), "1時間42秒前");
+
+        f.min_unit(TimeUnit::Nanoseconds);
+        assert_eq!(f.convert(Duration::from_nanos(42)), "42ナノ秒前");
+    }
+
+    test_with_formatter(Formatter::with_language(Japanese));
+    test_with_formatter(Formatter::with_language(Japanese.clone_boxed()));
 }


### PR DESCRIPTION
Japanese does not put spaces between words, but the `Japanese` language inherited the default `" "` for `between_value_and_word` / `between_chunks` / `override_space_near_ago`, so durations rendered as "5 分 前" and "1 週間 前" instead of "5分前" / "1週間前".

The `Japanese` impl dates back to #13 (2018), before those spacing hooks existed; when they were added (#36) with a `" "` default, Japanese was never updated to opt out. This overrides the three hooks to `""`, the same approach Korean already carries for `between_value_and_word` (#38).

Adds a test (Japanese had none) covering both the direct and the `BoxedLanguage` paths, mirroring the Korean test.